### PR TITLE
尝试修复近期发现的潜影盒发射问题

### DIFF
--- a/src/main/java/xyz/xy718/safeshulker/XySafeShulkerBoxPlugin.java
+++ b/src/main/java/xyz/xy718/safeshulker/XySafeShulkerBoxPlugin.java
@@ -7,6 +7,10 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.plugin.Plugin;
+import org.spongepowered.api.event.block.*;
+import org.spongepowered.api.block.*;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.util.Direction;
 
 import lombok.Getter;
 import xyz.xy718.safeshulker.event.BoxEvent;
@@ -26,23 +30,36 @@ public class XySafeShulkerBoxPlugin {
 	
 	public static final Logger LOGGER = LoggerFactory.getLogger("XySafeShulkerBox");
 	
-    public XySafeShulkerBoxPlugin() {
-    	if (instance != null) {
+	public XySafeShulkerBoxPlugin() {
+		if (instance != null) {
 			throw new IllegalStateException();
 		}
 		instance = this;
 	}
 
-    @Listener
-    public void onGameStarting(GameInitializationEvent event) {
-    	LOGGER.info("SafeShulkerBox开始注册事件~");
-    	Sponge.getEventManager().registerListeners(this,new BoxEvent());
+	@Listener
+	public void onGameStarting(GameInitializationEvent event) {
+		LOGGER.info("SafeShulkerBox开始注册事件~");
+		Sponge.getEventManager().registerListeners(this,new BoxEvent());
 	}
-    @Listener
-    public void onServerStart(GameStartedServerEvent event) {
-    	LOGGER.info("服务器启动成功，SafeShulkerBox也开始工作了~");
-    }
-    
+	@Listener
+	public void onServerStart(GameStartedServerEvent event) {
+		LOGGER.info("服务器启动成功，SafeShulkerBox也开始工作了~");
+	}
+	@Listener
+	public void onSDC(TickBlockEvent event)
+	{
+		int targetX = event.getTargetBlock().getPosition().getX();
+		int targetY = event.getTargetBlock().getPosition().getY();
+		int targetZ = event.getTargetBlock().getPosition().getZ();
+		
+		if(event.getTargetBlock().getState().getType()==BlockTypes.DISPENSER && ((targetY==255&&event.getTargetBlock().getExtendedState().get(Keys.DIRECTION).get()==Direction.UP) || (targetY==0&&event.getTargetBlock().getExtendedState().get(Keys.DIRECTION).get()==Direction.DOWN))
+		) {
+			LOGGER.warn("SafeShulkerBox检测到有发射器在边界处发射潜影盒！坐标：x="+targetX+", y="+targetY+", z="+targetZ);
+			event.setCancelled(true);
+		}
+	}
+	
 	public static XySafeShulkerBoxPlugin get() {
 		if (instance == null) {
 			throw new IllegalStateException("Instance not available");


### PR DESCRIPTION
该合并请求尝试修复了在世界上/下边界使用发射器发射有内容物的潜影盒会导致游戏崩溃的问题。
[参考自MCUmbrella/AntiShulkerDispenserCrash](https://github.com/MCUmbrella/AntiShulkerDispenserCrash)
This is a fix pull request which fixes the issue that can crash games when dispenser launch an noneempty shulker box in the top/bottom border of worlds.
Refered from MCUmbrella's AntiShulkerDispenserCrash.